### PR TITLE
fix: move upgrade flag to the default plugin list

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
   ape-plugins-list:
     description: 'Space seperated list of plugins to install with relevant pinning applied'
     required: False
-    default: '.'
+    default: '-U .'
 
 
 runs:
@@ -58,7 +58,7 @@ runs:
   - run: pip install eth-ape${{ inputs.ape-version-pin }}
     shell: bash
 
-  - run: ape plugins install -U ${{ inputs.ape-plugins-list }}
+  - run: ape plugins install ${{ inputs.ape-plugins-list }}
     shell: bash
 
   - name: Find if requirements.txt if exists


### PR DESCRIPTION
Move the -U upgrade flag to the default behavior of ape-plugins-list to allow for custom versions to be installed that can not be done at the same time as the -U. 

Fixes part of issue https://github.com/ApeWorX/github-action/issues/16

The upgrade flag will still cause issues if the version is specified in the ape-config.yaml