### PR TITLE
fix: pip cache key would be empty and couldn't use naked versions [APE-1179]

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,18 +14,31 @@ concurrency:
 
 jobs:
   run-this-action:
-    name: Run action (${{ matrix.runs-on }}, version ${{ matrix.version }})
-    runs-on: ${{ matrix.runs-on }}
+    name: Run action (${{ matrix.version }})
+    runs-on: [ubuntu-latest]
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, macos-latest]
+        version: ["default", "0.6.11", "==0.6.11", "git+https://github.com/ApeWorX/ape.git@main"]
     steps:
       - uses: actions/checkout@v3
 
-      - name: Run this action
+      - name: Check version pin
+        id: check-version
+        run: |
+          if [[ ${{ matrix.version }} == "default" ]]; then
+            echo "ape-version=''" >> $GITHUB_OUTPUT
+          else
+            echo "ape-version=${{ matrix.version }}" >> $GITHUB_OUTPUT
+          fi
+      - name: Run ape action
+        id: ape-action
         uses: ./
         with:
-          version: ${{ matrix.version }}
+          ape-version-pin: ${{ steps.check-version.outputs.ape-version }}
 
       - run: ape --help
+
+      - name: Print outputs
+        run: |
+          echo "Output: ${{ steps.ape-action.outputs.ape-version }}"

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "tabWidth": 2
+}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Default is using Python `'3.8'`.
 Default is to use the latest version of `eth-ape` (no pin).
 Can also use a `git+` value to install a branch, commit, or tag.
 
+Example values:
+
+* `1.0.0`
+* `==1.0.0`
+* `>=1.0.0,<2.0`
+* `git+https://github.com/your-github/ape.git@your-branch`
+
 ### `ape-plugins-list`
 
 **Optional** Space-separated list of plugins to install.
@@ -24,7 +31,10 @@ Note: When requesting a pin, put it all together like `'plugin-a plugin-b==1.2.3
 
 ## Outputs
 
-No outputs.
+### `ape-version`
+
+The version of Ape installed.
+This will either be the same as the `ape-version-pin` input if you provided that, else it will be the latest version found from `pypi`.
 
 ## Example usage
 
@@ -33,9 +43,9 @@ steps:
   - uses: actions/checkout@v3
   - uses: ApeWorX/github-action@v2
     with:
-      python-version: "3.10"  # (optional)
-      ape-version-pin: ">=0.6.0"  # (optional)
-      ape-plugins-list: "solidity vyper==0.6.2"  # (optional)
+      python-version: '3.10' # (optional)
+      ape-version-pin: '>=0.6.0' # (optional)
+      ape-plugins-list: 'solidity vyper==0.6.2' # (optional)
   - run: ape test -s
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   color: 'green'
 
 inputs:
-  python-version: 
+  python-version:
     description: 'Override version of python used to run ape- default 3.8'
     required: False
     default: '3.8'
@@ -18,64 +18,86 @@ inputs:
     required: False
     default: '-U .'
 
+outputs:
+  ape-version:
+    description: 'The version of Ape installed'
 
 runs:
   using: 'composite'
 
   steps:
-  
-  - uses: actions/cache@v3
-    with:
-      path: |
-        /home/runner/.solcx
-        /home/runner/.vvm/vyper-*
-      key: ${{ runner.os }}-compiler-cache
+    - uses: actions/cache@v3
+      with:
+        path: |
+          /home/runner/.solcx
+          /home/runner/.vvm/vyper-*
+        key: ${{ runner.os }}-compiler-cache
 
-  - uses: actions/cache@v3
-    with:
-      path: |
-        ${{ github.workspace }}/.build
-      key: ${{ runner.os }}-build-cache
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ${{ github.workspace }}/.build
+        key: ${{ runner.os }}-build-cache
 
-  - uses: actions/setup-python@v4
-    with:
-      python-version: ${{ inputs.python-version }}
-  
-  - name: Set pip cache directory path
-    id: pip-cache-dir-path
-    run: |
-      echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-    shell: bash
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
 
-  - name: Restore pip cache
-    uses: actions/cache@v3
-    id: pip-cache
-    with:
-      path: |
-        ${{ steps.pip-cache-dir-path.outputs.dir }}
-      key: ${{ inputs.python-version }}-pip-${{ inputs.ape-version-pin }}
+    - name: Set pip cache directory path
+      id: pip-cache-dir-path
+      run: |
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+      shell: bash
 
-  - run: |
-      pip install --upgrade pip
-      if [[ "${{ inputs.ape-version-pin }}" == git+* ]]
-      then
-        echo "INFO: Installing from a remote git version."
-        pip install ${{ inputs.ape-version-pin }}
-      else
-        pip install eth-ape${{ inputs.ape-version-pin }}
-      fi
-    shell: bash
+    - name: Determine ape version to use
+      id: determine-version
+      run: |
+        if [[ "${{ inputs.ape-version-pin }}" != "" && "${{ inputs.ape-version-pin }}" != "''" ]]; then
+          echo "ape-version=${{ inputs.ape-version-pin }}" >> $GITHUB_OUTPUT
+        else
+          latest_version=$(curl -s https://pypi.org/pypi/eth-ape/json | jq -r '.info.version')
+          echo "ape-version=${latest_version}" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
 
-  - run: ape plugins install ${{ inputs.ape-plugins-list }}
-    shell: bash
+    - name: Restore pip cache
+      uses: actions/cache@v3
+      id: pip-cache
+      with:
+        path: |
+          ${{ steps.pip-cache-dir-path.outputs.dir }}
+        key: ${{ inputs.python-version }}-pip-${{ steps.determine-version.outputs.ape-version }}
 
-  - name: Find if requirements.txt if exists
-    id: find-requirements-txt
-    run: |
-      echo "file=$(ls requirements.txt)" >> $GITHUB_OUTPUT
-    shell: bash
+    - name: Install Ape
+      run: |
+        pip install --upgrade pip
+        if [[ "${{ steps.determine-version.outputs.ape-version }}" == git+* ]]
+        then
+          echo "INFO: Installing from a remote git version."
+          pip install ${{ steps.determine-version.outputs.ape-version }}
+        else
+          version_regex='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+          if [[ ${{ steps.determine-version.outputs.ape-version }} =~ $version_regex ]]; then
+            # Allows for excluding `==` to `ape-version-pin`
+            echo "Installing with == prefix"
+            pip install eth-ape==${{ steps.determine-version.outputs.ape-version }}
+          else
+            echo "Installing using given constraints"
+            pip install eth-ape${{ steps.determine-version.outputs.ape-version }}
+          fi
+        fi
+      shell: bash
 
-  - name: Install requirements.txt
-    run: pip install -r requirements.txt
-    shell: bash
-    if: steps.find-requirements-txt.outputs.file == 'requirements.txt'
+    - run: ape plugins install ${{ inputs.ape-plugins-list }}
+      shell: bash
+
+    - name: Find if requirements.txt if exists
+      id: find-requirements-txt
+      run: |
+        echo "file=$(ls requirements.txt)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Install requirements.txt
+      run: pip install -r requirements.txt
+      shell: bash
+      if: steps.find-requirements-txt.outputs.file == 'requirements.txt'


### PR DESCRIPTION
fixes: #24 
Fixes: APE-1179

1. fix: Fixes an issue where the GitHub action would not use an updated version of Ape when it existed when you excluded `ape-version-pin`. This was quite problematic and explains some anomalies we have seen. Basically, the cache key was just `pip-38-` and if you updated Ape, it would not care and would use the Ape from the cache.

To fix this, now, if you exclude `ape-version-pin`, we will lookup the latest version from pypi and use that rather than an empty `pip install` command. This way, we can properly cache the version ahead of time as well as check for the existence of the key. N**ow, when an Ape is released in between when a PR is first opened and when subsequent pushes to the PR's branch are done, it will update and use the newer Ape.**

2. feat: Allows for setting versions without constraints. Before, if you tried to use `0.6.12` as the `ape-version-pin` value, it would error because it was expecting something like `==0.6.12`. That is not always obvious. It is nice that we support that but it is weird to not allow naked versions as well. So this PR allows setting versions normally.

3. test: add test matrices for each of the parameter types you can provider for `ape-version-pin`. These tests helped me immensely (TDD).

4. chore: run prettier and add a `.prettierrc` to try and match the existing style