### PR TITLE
fix: update default python version from 3.8 to 3.10 to align with framework

### DIFF
--- a/.github/workflows/test_ape_version.yaml
+++ b/.github/workflows/test_ape_version.yaml
@@ -22,8 +22,8 @@ jobs:
         version:
           [
             'default',
-            '0.7.0',
-            '==0.7.0',
+            '0.8.0',
+            '==0.8.0',
             'git+https://github.com/ApeWorX/ape.git@main',
           ]
     steps:

--- a/.github/workflows/test_ape_version.yaml
+++ b/.github/workflows/test_ape_version.yaml
@@ -22,8 +22,8 @@ jobs:
         version:
           [
             'default',
-            '0.8.0',
-            '==0.8.0',
+            '0.8.10',
+            '==0.8.10',
             'git+https://github.com/ApeWorX/ape.git@main',
           ]
     steps:

--- a/.github/workflows/test_plugins.yaml
+++ b/.github/workflows/test_plugins.yaml
@@ -23,7 +23,7 @@ jobs:
           'default_with_version_config',
           'default_without_version_in_config',
           'tokens',
-          'tokens==0.7.0'
+          'tokens==0.8.0'
         ]
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
 
           if [[ "${{ matrix.plugins }}" == "default_without_version_in_config" ]]; then
             # Remove the version so it defaults to `. -U`.
-            sed -i 's/version: 0.7.0//g' "ape-config.yaml"
+            sed -i 's/version: 0.8.0//g' "ape-config.yaml"
           fi
 
       - name: Run ape action

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This action allows you to use your favorte [`ape`](https://github.com/ApeWorX/ap
 ### `python-version`
 
 **Optional** Overrides the version of python used to run ape.
-Default is using Python `'3.8'`.
+Default is using Python `'3.10'`.
 
 ### `ape-version-pin`
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ steps:
   - uses: ApeWorX/github-action@v2
     with:
       python-version: '3.10' # (optional)
-      ape-version-pin: '>=0.7.0' # (optional)
-      ape-plugins-list: 'solidity vyper==0.7.0' # (optional)
+      ape-version-pin: '>=0.8.0' # (optional)
+      ape-plugins-list: 'solidity vyper==0.8.0' # (optional)
   - run: ape test -s
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ steps:
   - uses: ApeWorX/github-action@v2
     with:
       python-version: '3.10' # (optional)
-      ape-version-pin: '>=0.8.0' # (optional)
-      ape-plugins-list: 'solidity vyper==0.8.0' # (optional)
+      ape-version-pin: '>=0.8.10' # (optional)
+      ape-plugins-list: 'solidity vyper==0.8.4' # (optional)
   - run: ape test -s
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,9 @@ branding:
 
 inputs:
   python-version:
-    description: 'Override version of python used to run ape- default 3.8'
+    description: 'Override version of python used to run ape- default 3.10'
     required: False
-    default: '3.8'
+    default: '3.10'
   ape-version-pin:
     description: 'Override version of eth-ape, can also use a `git+` prefixed value'
     required: False

--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -1,4 +1,4 @@
 # This file exists only as a test for the action.
 plugins:
   - name: tokens
-    version: 0.7.0
+    version: 0.8.0


### PR DESCRIPTION
Python 3.8 doesn't work with Ape so it is unfortunate it is still the default Python version.
This PR changes it to 3.10 which seems to be what everyone is doing.