### PR TITLE
feat: macOS runner support

### DIFF
--- a/.github/workflows/test_ape_version.yaml
+++ b/.github/workflows/test_ape_version.yaml
@@ -22,8 +22,8 @@ jobs:
         version:
           [
             'default',
-            '0.8.10',
-            '==0.8.10',
+            '0.8.24',
+            '==0.8.24',
             'git+https://github.com/ApeWorX/ape.git@main',
           ]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_ape_version.yaml
+++ b/.github/workflows/test_ape_version.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Check version pin
         id: check-version
         run: |
-          if [[ ${{ matrix.version }} == "default" ]]; then
+          if [[ "${{ matrix.version }}" == "default" ]]; then
             echo "ape-version=''" >> $GITHUB_OUTPUT
           else
             echo "ape-version=${{ matrix.version }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/test_ape_version.yaml
+++ b/.github/workflows/test_ape_version.yaml
@@ -13,8 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run-this-action:
-    name: Run action (${{ matrix.version }})
+  test-version:
+    name: Test version (${{ matrix.os }} ${{ matrix.version }})
     strategy:
       fail-fast: false
       matrix:
@@ -27,6 +27,8 @@ jobs:
             'git+https://github.com/ApeWorX/ape.git@main',
           ]
     runs-on: ${{ matrix.os }}
+    env:
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test_ape_version.yaml
+++ b/.github/workflows/test_ape_version.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         version:
           [
             'default',

--- a/.github/workflows/test_ape_version.yaml
+++ b/.github/workflows/test_ape_version.yaml
@@ -15,10 +15,10 @@ concurrency:
 jobs:
   run-this-action:
     name: Run action (${{ matrix.version }})
-    runs-on: [ubuntu-latest]
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         version:
           [
             'default',
@@ -26,6 +26,7 @@ jobs:
             '==0.8.10',
             'git+https://github.com/ApeWorX/ape.git@main',
           ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test_plugins.yaml
+++ b/.github/workflows/test_plugins.yaml
@@ -38,7 +38,7 @@ jobs:
 
           if [[ "${{ matrix.plugins }}" == "default_without_version_in_config" ]]; then
             # Remove the version so it defaults to `. -U`.
-            awk '!/version: 0.8.4/' "ape-config.yaml" > "ape-config.tmp" && mv "ape-config.tmp" "ape-config.yaml"
+            awk '!/version: 0.8.3/' "ape-config.yaml" > "ape-config.tmp" && mv "ape-config.tmp" "ape-config.yaml"
           fi
 
       - name: Run ape action

--- a/.github/workflows/test_plugins.yaml
+++ b/.github/workflows/test_plugins.yaml
@@ -23,7 +23,7 @@ jobs:
           'default_with_version_config',
           'default_without_version_in_config',
           'tokens',
-          'tokens==0.8.0'
+          'tokens==0.8.3'
         ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -38,7 +38,7 @@ jobs:
 
           if [[ "${{ matrix.plugins }}" == "default_without_version_in_config" ]]; then
             # Remove the version so it defaults to `. -U`.
-            awk '!/version: 0.8.0/' "ape-config.yaml" > "ape-config.tmp" && mv "ape-config.tmp" "ape-config.yaml"
+            awk '!/version: 0.8.4/' "ape-config.yaml" > "ape-config.tmp" && mv "ape-config.tmp" "ape-config.yaml"
           fi
 
       - name: Run ape action

--- a/.github/workflows/test_plugins.yaml
+++ b/.github/workflows/test_plugins.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         plugins: [
           'default_with_version_config',
           'default_without_version_in_config',

--- a/.github/workflows/test_plugins.yaml
+++ b/.github/workflows/test_plugins.yaml
@@ -39,7 +39,6 @@ jobs:
           if [[ "${{ matrix.plugins }}" == "default_without_version_in_config" ]]; then
             # Remove the version so it defaults to `. -U`.
             awk '!/version: 0.8.0/' "ape-config.yaml" > "ape-config.tmp" && mv "ape-config.tmp" "ape-config.yaml"
-            sed -i 's/version: 0.8.0//g' "ape-config.yaml"
           fi
 
       - name: Run ape action

--- a/.github/workflows/test_plugins.yaml
+++ b/.github/workflows/test_plugins.yaml
@@ -15,16 +15,17 @@ concurrency:
 jobs:
   run-this-action:
     name: Run action (${{ matrix.plugins }})
-    runs-on: [ubuntu-latest]
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         plugins: [
           'default_with_version_config',
           'default_without_version_in_config',
           'tokens',
           'tokens==0.8.0'
         ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test_plugins.yaml
+++ b/.github/workflows/test_plugins.yaml
@@ -38,6 +38,7 @@ jobs:
 
           if [[ "${{ matrix.plugins }}" == "default_without_version_in_config" ]]; then
             # Remove the version so it defaults to `. -U`.
+            awk '!/version: 0.8.0/' "ape-config.yaml" > "ape-config.tmp" && mv "ape-config.tmp" "ape-config.yaml"
             sed -i 's/version: 0.8.0//g' "ape-config.yaml"
           fi
 

--- a/.github/workflows/test_plugins.yaml
+++ b/.github/workflows/test_plugins.yaml
@@ -13,8 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run-this-action:
-    name: Run action (${{ matrix.plugins }})
+  test-plugins:
+    name: Test plugins (${{ matrix.plugins }})
     strategy:
       fail-fast: false
       matrix:
@@ -26,6 +26,8 @@ jobs:
           'tokens==0.8.3'
         ]
     runs-on: ${{ matrix.os }}
+    env:
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ steps:
   - uses: ApeWorX/github-action@v3
     with:
       python-version: '3.10' # (optional)
-      ape-version-pin: '>=0.8.10' # (optional)
-      ape-plugins-list: 'solidity vyper==0.8.4' # (optional)
+      ape-version-pin: '>=0.8.24' # (optional)
+      ape-plugins-list: 'solidity vyper==0.8.8' # (optional)
   - run: ape test -s
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -142,15 +142,18 @@ runs:
         # in the cache action:
         # https://github.com/actions/cache/issues/1241
 
-        if [ ! -d "/home/runner/.solcx" ]; then
-          mkdir -p "/home/runner/.solcx"
-          echo "Solcx directory created."
-        fi
-        if [ ! -d "/home/runner/.vvm" ]; then
-          mkdir -p "/home/runner/.vvm"
-          echo "VVM directory created."
-        fi
-        if [ ! -d "${{ github.workspace }}/.build" ]; then
-          mkdir -p "${{ github.workspace }}/.build"
-          echo ".build directory created."
+        # NOTE: If /home/runner does not exist, mkdir fails.
+        if [ -d "/home/runner" ]; then
+          if [ ! -d "/home/runner/.solcx" ]; then
+            mkdir "/home/runner/.solcx"
+            echo "Solcx directory created."
+          fi
+          if [ ! -d "/home/runner/.vvm" ]; then
+            mkdir "/home/runner/.vvm"
+            echo "VVM directory created."
+          fi
+          if [ ! -d "${{ github.workspace }}/.build" ]; then
+            mkdir "${{ github.workspace }}/.build"
+            echo ".build directory created."
+          fi
         fi

--- a/action.yml
+++ b/action.yml
@@ -143,14 +143,14 @@ runs:
         # https://github.com/actions/cache/issues/1241
 
         if [ ! -d "/home/runner/.solcx" ]; then
-          mkdir "/home/runner/.solcx"
+          mkdir -p "/home/runner/.solcx"
           echo "Solcx directory created."
         fi
         if [ ! -d "/home/runner/.vvm" ]; then
-          mkdir "/home/runner/.vvm"
+          mkdir -p "/home/runner/.vvm"
           echo "VVM directory created."
         fi
         if [ ! -d "${{ github.workspace }}/.build" ]; then
-          mkdir "${{ github.workspace }}/.build"
+          mkdir -p "${{ github.workspace }}/.build"
           echo ".build directory created."
         fi

--- a/action.yml
+++ b/action.yml
@@ -143,17 +143,17 @@ runs:
         # https://github.com/actions/cache/issues/1241
 
         # NOTE: If /home/runner does not exist, mkdir fails.
-        if [ -d "/home/runner" ]; then
-          if [ ! -d "/home/runner/.solcx" ]; then
-            mkdir "/home/runner/.solcx"
+        if [ -d "$HOME" ]; then
+          if [ ! -d "$HOME/.solcx" ]; then
+            mkdir "$HOME/.solcx"
             echo "Solcx directory created."
           fi
-          if [ ! -d "/home/runner/.vvm" ]; then
-            mkdir "/home/runner/.vvm"
+          if [ ! -d "$HOME/.vvm" ]; then
+            mkdir "$HOME/.vvm"
             echo "VVM directory created."
           fi
-          if [ ! -d "${{ github.workspace }}/.build" ]; then
-            mkdir "${{ github.workspace }}/.build"
+          if [ ! -d "$HOME/.build" ]; then
+            mkdir "$HOME/.build"
             echo ".build directory created."
           fi
         fi

--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -1,4 +1,4 @@
 # This file exists only as a test for the action.
 plugins:
   - name: tokens
-    version: 0.8.4
+    version: 0.8.3

--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -1,4 +1,4 @@
 # This file exists only as a test for the action.
 plugins:
   - name: tokens
-    version: 0.8.0
+    version: 0.8.4


### PR DESCRIPTION
### What I did

an annoying handler for repressing a warning causes the action to fail.

### How I did it

use -p so that mkdir will just make all the parents if it really has to, hopefully that doesnt matter too much

### How to verify it

im testing it in ape-titanoboa right now, this is blocking it from using the action which i kinda need to use for caching reasons.

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
