### PR TITLE
fix: issue where macos runners never cached compilers

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,8 +30,8 @@ runs:
       name: Compilers cache
       with:
         path: |
-          /home/runner/.solcx
-          /home/runner/.vvm/vyper-*
+          $HOME/.solcx
+          $HOME/.vvm/vyper-*
         key: ${{ runner.os }}-compiler-cache
 
     - uses: actions/cache@v4
@@ -142,7 +142,7 @@ runs:
         # in the cache action:
         # https://github.com/actions/cache/issues/1241
 
-        # NOTE: If /home/runner does not exist, mkdir fails.
+        # NOTE: If HOME does not exist, mkdir fails.
         if [ -d "$HOME" ]; then
           if [ ! -d "$HOME/.solcx" ]; then
             mkdir "$HOME/.solcx"


### PR DESCRIPTION
### What I did

/home/runner is only the ubuntu home name, causing the cache key to never be hit.

### How I did it

Use $HOME

### How to verify it

I can test it out in ape-titanoboa

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
