### PR TITLE
test: add `pyproject.toml` test to actions CI

### DIFF
--- a/.github/workflows/test_ape_version.yaml
+++ b/.github/workflows/test_ape_version.yaml
@@ -26,6 +26,10 @@ jobs:
             '==0.8.24',
             'git+https://github.com/ApeWorX/ape.git@main',
           ]
+        extra-packages: [
+          'requirements.txt',
+          'pyproject.toml',
+        ]
     runs-on: ${{ matrix.os }}
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -40,18 +44,26 @@ jobs:
           else
             echo "ape-version=${{ matrix.version }}" >> $GITHUB_OUTPUT
           fi
+
+      - name: Convert 'requirements.txt' to 'pyproject.toml'
+        if: ${{ matrix.extra-packages == 'pyproject.toml' }}
+        shell: bash
+        run: |
+          pip install tomlkit
+        python -c 'from pathlib import Path; txt = Path("requirements.txt").read_text(); import tomlkit; print(tomlkit.dumps({"project": {"dependencies": [line for line in txt.splitlines() if not line.startswith("#")], "name":"test", "version": "0.0.0"}}))' | tee pyproject.toml
+          rm requirements.txt
+
       - name: Run ape action
         id: ape-action
         uses: ./
         with:
           ape-version-pin: ${{ steps.check-version.outputs.ape-version }}
 
-      - run: ape --help
-
       - name: Print outputs
         run: |
-          echo "Output: ${{ steps.ape-action.outputs.ape-version }}"
-        
-      - name: Requirements.txt Test
-        run: |
-          pip show hypothesis
+          echo "Ape Version: ${{ steps.ape-action.outputs.ape-version }}"
+
+      - run: ape --help
+
+      - name: Extra packages Test
+        run: pip show hypothesis

--- a/.github/workflows/test_plugins.yaml
+++ b/.github/workflows/test_plugins.yaml
@@ -25,6 +25,10 @@ jobs:
           'tokens',
           'tokens==0.8.3'
         ]
+        config-file: [
+          'ape-config.yaml',
+          'pyproject.toml',
+        ]
     runs-on: ${{ matrix.os }}
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -42,6 +46,14 @@ jobs:
             # Remove the version so it defaults to `. -U`.
             awk '!/version: 0.8.3/' "ape-config.yaml" > "ape-config.tmp" && mv "ape-config.tmp" "ape-config.yaml"
           fi
+
+      - name: Convert 'ape-config.yaml' to 'pyproject.toml'
+        if: ${{ matrix.config-file == 'pyproject.toml' }}
+        shell: bash
+        run: |
+          pip install tomlkit PyYAML
+          python -c 'from pathlib import Path; import yaml; import tomlkit; print(tomlkit.dumps({"tool": {"ape": yaml.safe_load(Path("ape-config.yaml").read_text())}}))' | tee pyproject.toml
+          rm ape-config.yaml
 
       - name: Run ape action
         id: ape-action

--- a/.github/workflows/test_plugins.yaml
+++ b/.github/workflows/test_plugins.yaml
@@ -61,4 +61,22 @@ jobs:
         with:
           ape-plugins-list: ${{ steps.check-plugins.outputs.ape-plugins }}
 
-      - run: ape plugins list
+      - name: Check results
+        shell: bash
+        run: |
+          result="$(ape plugins list | grep -o 'tokens.*' | grep -o '[0-9\.]*')"
+
+          if [[ "${{ matrix.plugins }}" == "default_without_version_in_config" || "${{ matrix.plugins }}" == "tokens" ]];
+          then
+            if [[ $result == "0.8.3" ]];
+            then
+              echo "Expected $result to be greater than 0.8.3"
+              exit 1;
+            fi
+          else
+            if [[ $result != "0.8.3" ]];
+            then
+              echo "Expected $result to be equal to 0.8.3"
+              exit 1;
+            fi
+          fi

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,9 @@ branding:
 
 inputs:
   python-version:
-    description: 'Override version of python used to run ape- default 3.10'
+    description: 'Override version of python used to run ape - default 3.11'
     required: False
-    default: '3.10'
+    default: '3.11'
   ape-version-pin:
     description: 'Override version of eth-ape, can also use a `git+` prefixed value'
     required: False
@@ -100,19 +100,27 @@ runs:
       uses: andstor/file-existence-action@v3
       with:
         files: 'ape-config.yaml'
-      
+
+    - name: Check pyproject.toml exists
+      id: check-pyproject-toml
+      uses: andstor/file-existence-action@v3
+      with:
+        files: 'pyproject.toml'
+
     - name: Check version specs in config
       id: check-plugin-version-specs
       run: |
         if [[ "${{ steps.check-ape-config-yaml.outputs.files_exists }}" == "true" ]]; then
           version_present=$(sed -n '/^plugins:/,/^[^ ]/{/version:/p;}' "ape-config.yaml" | grep -c version || true)
-          if [[ -z "${version_present}" ]]; then
-            echo "version_present=0" >> $GITHUB_OUTPUT
-          else
-            echo "version_present=1" >> $GITHUB_OUTPUT
-          fi
+        elif [[ "${{ steps.check-pyproject-toml.outputs.files_exists }}" == "true" ]]; then
+          version_present=$(python -c "from pathlib import Path; import tomllib; config = tomllib.loads(Path('pyproject.toml').read_text()); print('true' if any('version' in plugin for plugin in config.get('tool', {}).get('ape', {}).get('plugins', [])) else '')")
         else
+          version_present=""
+        fi
+        if [[ -z "${version_present}" ]]; then
           echo "version_present=0" >> $GITHUB_OUTPUT
+        else
+          echo "version_present=1" >> $GITHUB_OUTPUT
         fi
       shell: bash
 
@@ -126,7 +134,7 @@ runs:
           plugins_value="${{ inputs.ape-plugins-list }}"
         fi
 
-        ape plugins install $plugins_value
+        ape plugins install --verbosity DEBUG $plugins_value
 
       shell: bash
     - name: Check requirments.txt exists
@@ -134,11 +142,15 @@ runs:
       uses: andstor/file-existence-action@v3
       with:
         files: 'requirements.txt'
-  
-    - name: Install requirements.txt
-      run: pip install -r requirements.txt
+
+    - name: Install extra packages
       shell: bash
-      if: steps.check-requirements-txt.outputs.files_exists == 'true'
+      run: |
+        if [[ "${{ steps.check-requirements-txt.outputs.files_exists }}" == "true" ]]; then
+          pip install -r requirements.txt
+        elif [[ "${{ steps.check-pyproject-toml.outputs.files_exists }}" == "true" ]]; then
+          pip install .
+        fi
 
     - name: Ensure cache directories exist
       shell: bash


### PR DESCRIPTION
### What I did

Add support for `pyproject.toml` for both plugin detection and extra packages

fixes: #35

### How I did it

`pyproject.toml` can serve 2 purposes:
1. define `[tool.ape]` config that supercedes `ape-config.yaml`
2. define extra packages in `[project.dependencies]` that supercedes `requirements.txt`

So we need to test 4 scenarios:
1. `requirements.txt` and `ape-config.yaml`
2. `pyproject.toml` (with no `[tool.ape]` config) and `ape-config.yaml`
3. `requirements.txt` and `pyproject.toml` (with `[tool.ape]` config but no `[project]` key)
4. `pyproject.toml` (with bot `[tool.ape]` config and `[project.dependencies]` keys)

### How to verify it

New tests
Also testing w/ https://github.com/fubuloubu/Purse/pull/7

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete