### PR TITLE
feat: allow path-based install for Ape

### DIFF
--- a/.github/workflows/test_ape_version.yaml
+++ b/.github/workflows/test_ape_version.yaml
@@ -22,8 +22,8 @@ jobs:
         version:
           [
             'default',
-            '0.8.24',
-            '==0.8.24',
+            '0.8.36',
+            '==0.8.36',
             'git+https://github.com/ApeWorX/ape.git@main',
             '<PATH_TO_APE>',
           ]
@@ -44,6 +44,14 @@ jobs:
         with:
           repository: ApeWorX/ape
           path: eth-ape
+
+      - name: Debug eth-ape folder
+        if: contains(matrix.version, '<PATH_TO_APE>')
+        run: |
+          echo "Listing current directory"
+          ls -la
+          echo "Listing eth-ape directory"
+          ls -la eth-ape || echo "eth-ape directory not found"
 
       - name: Check version pin
         id: check-version

--- a/.github/workflows/test_ape_version.yaml
+++ b/.github/workflows/test_ape_version.yaml
@@ -1,17 +1,3 @@
-name: Version Test
-
-on:
-  push:
-    branches: [main]
-    tags-ignore: ['**']
-    paths-ignore: ['**.md']
-  pull_request:
-    paths-ignore: ['**.md']
-
-concurrency:
-  group: ${{ github.ref }}-version
-  cancel-in-progress: true
-
 jobs:
   test-version:
     name: Test version (${{ matrix.os }} ${{ matrix.version }})
@@ -25,6 +11,7 @@ jobs:
             '0.8.24',
             '==0.8.24',
             'git+https://github.com/ApeWorX/ape.git@main',
+            '<PATH_TO_APE>',
           ]
         extra-packages: [
           'requirements.txt',
@@ -36,11 +23,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Checkout eth-ape repo if needed for <PATH_TO_APE>
+      - name: Checkout eth-ape
+        if: contains(matrix.version, '<PATH_TO_APE>')
+        uses: actions/checkout@v4
+        with:
+          repository: ApeWorX/ape
+          path: eth-ape
+
       - name: Check version pin
         id: check-version
         run: |
           if [[ "${{ matrix.version }}" == "default" ]]; then
             echo "ape-version=''" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.version }}" == "<PATH_TO_APE>" ]]; then
+            echo "ape-version=./eth-ape" >> $GITHUB_OUTPUT
           else
             echo "ape-version=${{ matrix.version }}" >> $GITHUB_OUTPUT
           fi
@@ -50,7 +47,7 @@ jobs:
         shell: bash
         run: |
           pip install tomlkit
-        python -c 'from pathlib import Path; txt = Path("requirements.txt").read_text(); import tomlkit; print(tomlkit.dumps({"project": {"dependencies": [line for line in txt.splitlines() if not line.startswith("#")], "name":"test", "version": "0.0.0"}}))' | tee pyproject.toml
+          python -c 'from pathlib import Path; txt = Path("requirements.txt").read_text(); import tomlkit; print(tomlkit.dumps({"project": {"dependencies": [line for line in txt.splitlines() if not line.startswith("#")], "name":"test", "version": "0.0.0"}}))' | tee pyproject.toml
           rm requirements.txt
 
       - name: Run ape action

--- a/.github/workflows/test_ape_version.yaml
+++ b/.github/workflows/test_ape_version.yaml
@@ -59,7 +59,7 @@ jobs:
           if [[ "${{ matrix.version }}" == "default" ]]; then
             echo "ape-version=''" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.version }}" == "<PATH_TO_APE>" ]]; then
-            echo "ape-version=./eth-ape" >> $GITHUB_OUTPUT
+            echo "ape-version=${{ github.workspace }}/eth-ape" >> $GITHUB_OUTPUT
           else
             echo "ape-version=${{ matrix.version }}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/test_ape_version.yaml
+++ b/.github/workflows/test_ape_version.yaml
@@ -1,3 +1,17 @@
+name: Version Test
+
+on:
+  push:
+    branches: [main]
+    tags-ignore: ['**']
+    paths-ignore: ['**.md']
+  pull_request:
+    paths-ignore: ['**.md']
+
+concurrency:
+  group: ${{ github.ref }}-version
+  cancel-in-progress: true
+
 jobs:
   test-version:
     name: Test version (${{ matrix.os }} ${{ matrix.version }})

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Default is using Python `'3.10'`.
 ### `ape-version-pin`
 
 **Optional** Overrides the pin used to install `eth-ape`.
-Default is to use the latest version of `eth-ape` (no pin).
-Can also use a `git+` value to install a branch, commit, or tag.
+The default is to use the latest version of `eth-ape` (no pin).
+You can use a `git+` value to install a branch, commit, or tag.
+You can also paths, such as `"."` if you already have Ape checked out.
 
 Example values:
 
@@ -21,6 +22,7 @@ Example values:
 - `==1.0.0`
 - `>=1.0.0,<2.0`
 - `git+https://github.com/your-github/ape.git@your-branch`
+- `$HOME/path/to/ape`
 
 ### `ape-plugins-list`
 

--- a/action.yml
+++ b/action.yml
@@ -68,8 +68,8 @@ runs:
     
             # Change into the directory to hash relative paths deterministically
             pushd "$input_version" >/dev/null
-    
-            HASH=$(find "$input_version" -type f -exec sha256sum {} + | sha256sum | cut -c1-16)
+        
+            HASH=$(find "$input_version" -type f -exec shasum -a 256 {} + | shasum -a 256 | cut -c1-16)
 
             popd >/dev/null
     

--- a/action.yml
+++ b/action.yml
@@ -59,11 +59,33 @@ runs:
     - name: Determine ape version to use
       id: determine-version
       run: |
-        if [[ "${{ inputs.ape-version-pin }}" != "" && "${{ inputs.ape-version-pin }}" != "''" ]]; then
-          echo "ape-version=${{ inputs.ape-version-pin }}" >> $GITHUB_OUTPUT
+        input_version="${{ inputs.ape-version-pin }}"
+    
+        if [[ "$input_version" != "" && "$input_version" != "''" ]]; then
+          if [[ -d "$input_version" ]]; then
+            # Using a local directory – generate hash of its contents for cache key
+            echo "INFO: Using local path: $input_version"
+    
+            # Change into the directory to hash relative paths deterministically
+            pushd "$input_version" >/dev/null
+    
+            HASH=$(find "$input_version" -type f -exec sha256sum {} + | sha256sum | cut -c1-16)
+
+            popd >/dev/null
+    
+            echo "ape-version=$input_version" >> "$GITHUB_OUTPUT"
+            echo "ape-cache-key=local-${HASH}" >> "$GITHUB_OUTPUT"
+            echo "Using local repo with hash: $HASH"
+    
+          else
+            echo "ape-version=$input_version" >> "$GITHUB_OUTPUT"
+            echo "ape-cache-key=$input_version" >> "$GITHUB_OUTPUT"
+          fi
+    
         else
           latest_version=$(curl -s https://pypi.org/pypi/eth-ape/json | jq -r '.info.version')
-          echo "ape-version=${latest_version}" >> $GITHUB_OUTPUT
+          echo "ape-version=$latest_version" >> "$GITHUB_OUTPUT"
+          echo "ape-cache-key=$latest_version" >> "$GITHUB_OUTPUT"
         fi
       shell: bash
 
@@ -73,24 +95,31 @@ runs:
       with:
         path: |
           ${{ steps.pip-cache-dir-path.outputs.dir }}
-        key: ${{ inputs.python-version }}-pip-${{ steps.determine-version.outputs.ape-version }}
+        key: ${{ inputs.python-version }}-pip-${{ steps.determine-version.outputs.ape-cache-key }}
 
     - name: Install Ape
       run: |
         pip install --upgrade pip
-        if [[ "${{ steps.determine-version.outputs.ape-version }}" == git+* ]]
-        then
+    
+        ape_version="${{ steps.determine-version.outputs.ape-version }}"
+    
+        if [[ "$ape_version" == git+* ]]; then
           echo "INFO: Installing from a remote git version."
-          pip install ${{ steps.determine-version.outputs.ape-version }}
+          pip install "$ape_version"
+    
+        elif [[ -d "$ape_version" ]]; then
+          echo "INFO: Installing from local path: $ape_version"
+          pip install "$ape_version"
+    
         else
           version_regex='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
-          if [[ ${{ steps.determine-version.outputs.ape-version }} =~ $version_regex ]]; then
-            # Allows for excluding `==` to `ape-version-pin`
-            echo "Installing with == prefix"
-            pip install eth-ape==${{ steps.determine-version.outputs.ape-version }}
+    
+          if [[ "$ape_version" =~ $version_regex ]]; then
+            echo "INFO: Installing eth-ape==$ape_version"
+            pip install "eth-ape==$ape_version"
           else
-            echo "Installing using given constraints"
-            pip install eth-ape${{ steps.determine-version.outputs.ape-version }}
+            echo "INFO: Installing eth-ape$ape_version"
+            pip install "eth-ape$ape_version"
           fi
         fi
       shell: bash


### PR DESCRIPTION
### What I did

I think this will make it so we only have to install Ape once in our usage of the action to test ape itself.
But also is a nice feature i think in the case you have Ape on some container already somewhere you can just point to it.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
